### PR TITLE
fix: prevent completion sound from replaying when reopening completed tasks (#4885)

### DIFF
--- a/packages/types/src/history.ts
+++ b/packages/types/src/history.ts
@@ -16,6 +16,7 @@ export const historyItemSchema = z.object({
 	totalCost: z.number(),
 	size: z.number().optional(),
 	workspace: z.string().optional(),
+	completionSoundPlayed: z.boolean().optional(),
 })
 
 export type HistoryItem = z.infer<typeof historyItemSchema>

--- a/src/core/task/Task.ts
+++ b/src/core/task/Task.ts
@@ -403,6 +403,16 @@ export class Task extends EventEmitter<ClineEvents> {
 
 			this.emit("taskTokenUsageUpdated", this.taskId, tokenUsage)
 
+			// Check if this is a completion save by looking for completion-related messages
+			const hasCompletionMessage = this.clineMessages.some(
+				(msg) => msg.ask === "completion_result" || msg.ask === "resume_completed_task",
+			)
+
+			// If we have a completion message, set the completionSoundPlayed flag
+			if (hasCompletionMessage) {
+				historyItem.completionSoundPlayed = true
+			}
+
 			await this.providerRef.deref()?.updateTaskHistory(historyItem)
 		} catch (error) {
 			console.error("Failed to save Roo messages:", error)

--- a/webview-ui/src/components/chat/ChatView.tsx
+++ b/webview-ui/src/components/chat/ChatView.tsx
@@ -333,7 +333,7 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 							break
 						case "completion_result":
 							// extension waiting for feedback. but we can just present a new task button
-							if (!isPartial) {
+							if (!isPartial && soundEnabled && !currentTaskItem?.completionSoundPlayed) {
 								playSound("celebration")
 							}
 							setSendingDisabled(isPartial)
@@ -354,9 +354,6 @@ const ChatViewComponent: React.ForwardRefRenderFunction<ChatViewRef, ChatViewPro
 							setDidClickCancel(false) // special case where we reset the cancel button state
 							break
 						case "resume_completed_task":
-							if (!isPartial) {
-								playSound("celebration")
-							}
 							setSendingDisabled(false)
 							setClineAsk("resume_completed_task")
 							setEnableButtons(true)

--- a/webview-ui/src/components/chat/__tests__/ChatView.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/ChatView.spec.tsx
@@ -884,51 +884,81 @@ describe("ChatView - Sound Playing Tests", () => {
 		})
 	})
 
-	it("plays celebration sound for completion results", async () => {
+	it("plays celebration sound for completion results when completionSoundPlayed is not set", async () => {
 		renderChatView()
 
-		// First hydrate state with initial task and streaming
+		const taskItem = {
+			id: "task-1",
+			number: 1,
+			ts: Date.now() - 2000,
+			task: "Initial task",
+			tokensIn: 100,
+			tokensOut: 50,
+			totalCost: 0.01,
+		}
+
+		// Send completion result without completionSoundPlayed flag
 		mockPostMessage({
 			clineMessages: [
-				{
-					type: "say",
-					say: "task",
-					ts: Date.now() - 2000,
-					text: "Initial task",
-				},
-				{
-					type: "say",
-					say: "api_req_started",
-					ts: Date.now() - 1000,
-					text: JSON.stringify({}),
-					partial: true,
-				},
+				{ type: "say", say: "task", ts: taskItem.ts, text: taskItem.task },
+				{ type: "ask", ask: "completion_result", ts: Date.now(), text: "Task completed", partial: false },
 			],
+			currentTaskItem: taskItem,
+			soundEnabled: true,
 		})
 
-		// Then send the completion result message (streaming finished)
+		await waitFor(() => expect(mockPlayFunction).toHaveBeenCalled())
+	})
+
+	it("does not play celebration sound when completionSoundPlayed is true", async () => {
+		renderChatView()
+
+		const taskItem = {
+			id: "task-1",
+			number: 1,
+			ts: Date.now() - 2000,
+			task: "Initial task",
+			tokensIn: 100,
+			tokensOut: 50,
+			totalCost: 0.01,
+			completionSoundPlayed: true,
+		}
+
+		// Send completion result with completionSoundPlayed flag
 		mockPostMessage({
 			clineMessages: [
-				{
-					type: "say",
-					say: "task",
-					ts: Date.now() - 2000,
-					text: "Initial task",
-				},
-				{
-					type: "ask",
-					ask: "completion_result",
-					ts: Date.now(),
-					text: "Task completed successfully",
-					partial: false,
-				},
+				{ type: "say", say: "task", ts: taskItem.ts, text: taskItem.task },
+				{ type: "ask", ask: "completion_result", ts: Date.now(), text: "Task completed", partial: false },
 			],
+			currentTaskItem: taskItem,
+			soundEnabled: true,
 		})
 
-		// Verify celebration sound was played
-		await waitFor(() => {
-			expect(mockPlayFunction).toHaveBeenCalled()
+		expect(mockPlayFunction).not.toHaveBeenCalled()
+	})
+
+	it("does not play sound when resuming a completed task", async () => {
+		renderChatView()
+
+		mockPostMessage({
+			clineMessages: [
+				{ type: "say", say: "task", ts: Date.now() - 2000, text: "Initial task" },
+				{ type: "ask", ask: "resume_completed_task", ts: Date.now(), text: "Resume", partial: false },
+			],
+			currentTaskItem: {
+				id: "task-1",
+				number: 1,
+				ts: Date.now() - 2000,
+				task: "Initial task",
+				tokensIn: 100,
+				tokensOut: 50,
+				totalCost: 0.01,
+				completionSoundPlayed: true,
+			},
+			soundEnabled: true,
 		})
+
+		expect(mockPlayFunction).not.toHaveBeenCalled()
 	})
 
 	it("plays progress_loop sound for api failures", async () => {


### PR DESCRIPTION
## Fixes #4885

### Problem
The completion notification sound was playing every time a user reopened an already completed task, which created a poor user experience and made the sound notification less meaningful.

### Solution
Implemented a `completionSoundPlayed` flag to track whether the completion sound has already been played for a task, preventing it from replaying when the task is reopened.

### Changes Made
- **`packages/types/src/history.ts`**: Added optional `completionSoundPlayed?: boolean` field to `HistoryItem` type
- **`webview-ui/src/components/chat/ChatView.tsx`**: Modified to check the flag before playing completion sound and prevent sound on task resumption
- **`src/core/task/Task.ts`**: Updated to persist the `completionSoundPlayed` flag when saving task state
- **`webview-ui/src/components/chat/__tests__/ChatView.spec.tsx`**: Updated tests to match the new behavior

### Testing Performed
- ✅ All existing tests pass
- ✅ New test coverage for the completion sound flag behavior
- ✅ Manual testing confirmed sound only plays once per task completion
- ✅ Linting and type checking pass

### Behavior
- **Before**: Completion sound played every time a completed task was reopened
- **After**: Completion sound plays only once when a task is actually completed, not when reopening

This change improves the user experience by making the completion sound more meaningful and less intrusive.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `completionSoundPlayed` flag to prevent replaying completion sound when reopening completed tasks, with updates to task logic and UI components.
> 
>   - **Behavior**:
>     - Adds `completionSoundPlayed` flag to `HistoryItem` in `history.ts` to track if completion sound has been played.
>     - In `ChatView.tsx`, checks `completionSoundPlayed` before playing sound for task completion.
>     - In `Task.ts`, sets `completionSoundPlayed` to `true` when a task is completed.
>   - **Testing**:
>     - Updates `ChatView.spec.tsx` to test new behavior, ensuring sound plays only once per task completion.
>     - Confirms no sound on reopening completed tasks if `completionSoundPlayed` is `true`.
>   - **Misc**:
>     - Ensures manual and automated tests pass, including linting and type checks.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=SannidhyaSah%2FRoo-Code&utm_source=github&utm_medium=referral)<sup> for 3b83ea96dac897457f3e84dcd8a94f606f37c12f. You can [customize](https://app.ellipsis.dev/SannidhyaSah/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->